### PR TITLE
Fix email settings boolean check

### DIFF
--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -352,7 +352,7 @@ class Config {
    * @returns {boolean} True if configuration has required email settings
    */
   hasValidEmailSettings() {
-    return (
+    return Boolean(
       this.get('TRACKER_EMAIL_SENDER') &&
       this.get('TRACKER_EMAIL_RECIPIENT') &&
       this.get('TRACKER_EMAIL_PASSWORD')


### PR DESCRIPTION
## Summary
- fix `hasValidEmailSettings` so it returns a boolean

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fc195f2c4832592d0e5cd409ce1b3