### PR TITLE
Fix boolean return from config.hasValidEmailSettings

### DIFF
--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -352,7 +352,7 @@ class Config {
    * @returns {boolean} True if configuration has required email settings
    */
   hasValidEmailSettings() {
-    return (
+    return Boolean(
       this.get('TRACKER_EMAIL_SENDER') &&
       this.get('TRACKER_EMAIL_RECIPIENT') &&
       this.get('TRACKER_EMAIL_PASSWORD')


### PR DESCRIPTION
## Summary
- ensure `hasValidEmailSettings` always returns a boolean

## Testing
- `npm test` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_683fc181b518832584e88ac6f5ba5d74